### PR TITLE
Upgrade NJOY2016 to version .73 keeping IAEA-NDS local patches

### DIFF
--- a/src/aceth.f90
+++ b/src/aceth.f90
@@ -1209,7 +1209,7 @@ contains
       endif
       write(nout,'(''0/'')')
       if (idpnc.eq.4.or.idpnc.eq.5) then
-         e=xss(itce+1)-xss(itce+1)/1000
+         e=xss(itce+1)
          xs=xss(itce+nee+1)/e
          xs=xs/100
          write(nout,'(1p,2e14.6,''/'')') e,xs
@@ -1220,7 +1220,7 @@ contains
          if (idpnc.eq.4.or.idpnc.eq.5) xs=xs/e
          write(nout,'(1p,2e14.6,''/'')') e,xs
          if ((idpnc.eq.4.or.idpnc.eq.5).and.i.lt.nee) then
-            e=xss(itce+i+1)-xss(itce+i+1)/1000
+            e=xss(itce+i+1)
             xs=xss(itce+nee+i)/e
             write(nout,'(1p,2e14.6,''/'')') e,xs
          endif
@@ -1280,7 +1280,7 @@ contains
          endif
       enddo
       if (idpnc.eq.4.or.idpnc.eq.5) then
-         e=xss(itce+1)-xss(itce+1)/1000
+         e=xss(itce+1)
          j=0
          do while (j.lt.nie)
             j=j+1
@@ -1333,7 +1333,7 @@ contains
          tot=xs+xn+xielas
          write(nout,'(1p,2e14.6,''/'')') e,tot
          if (i.lt.nee.and.(idpnc.eq.4.or.idpnc.eq.5)) then
-            e=xss(itce+i+1)-xss(itce+i+1)/1000
+            e=xss(itce+i+1)
             xs=xss(itce+nee+i)/e
             j=0
             do while (j.lt.nie)
@@ -2039,7 +2039,7 @@ contains
                if (k.eq.nang.and.un-u.gt.5*(u-ul)) un=u+3*(u-ul)
                p=1
                p=p/nang
-               p=p/(un-ul)
+               if (un.ne.ul) p=p/(un-ul)
                ul=un
             enddo
          endif
@@ -2083,7 +2083,7 @@ contains
                   if (k.eq.nang.and.un-u.gt.5*(u-ul)) un=u+3*(u-ul)
                   p=1
                   p=p/nang
-                  p=p/(un-ul)
+                  if (un.ne.ul) p=p/(un-ul)
                   if (k.eq.1) write(nout,'(1p,2e14.6,''/'')') ul,zmin
                   write(nout,'(1p,2e14.6,''/'')') u,p
                   if (k.eq.nang) write(nout,'(1p,2e14.6,''/'')') un,zmin

--- a/src/groupr.f90
+++ b/src/groupr.f90
@@ -7459,7 +7459,7 @@ contains
    real(kr)::zad,elo,ehi,apsx,enow,eihi,ep,epnext,en
    real(kr)::pspmax,yldd,el,eh,e0,g0,e1,e2,test,pe,disc102
    real(kr)::val,fx,ex,cx,cxx,rn,dx
-   integer(kr)::nx,ncyc,n,ix
+   integer::nx,ncyc,n,ix
    integer,parameter::mxlg=65
    real(kr)::term(mxlg),terml(mxlg)
    integer,parameter::maxss=500

--- a/src/leapr.f90
+++ b/src/leapr.f90
@@ -47,6 +47,9 @@ module leapm
    real(kr),dimension(:),allocatable::dwpix,dwp1
    real(kr),dimension(:),allocatable::tempf,tempf1
 
+   ! min phonon expansion for time warning message
+   integer,parameter,public::maxnphon=250
+
 contains
 
    subroutine leapr
@@ -220,6 +223,7 @@ contains
    integer::isym,mscr,maxb,isecs
    real(kr)::time
    character(4)::title(20)
+   character(60)::strng
    real(kr)::temp,emax
    character::text*80
    real(kr),dimension(:),allocatable::bragg
@@ -293,6 +297,12 @@ contains
    allocate(beta(nbeta))
    read(nsysi,*) (alpha(i),i=1,nalpha)
    read(nsysi,*) (beta(i),i=1,nbeta)
+
+   ! warn for excessive computation time
+   if (nphon.gt.maxnphon) then
+      write(strng,'('' phonon expansion order is larger than '',i3)') maxnphon
+      call mess('leapr',strng,'calculation time may be excessive')
+   endif
 
    !--open the output unit
    call openz(nout,1)
@@ -373,11 +383,11 @@ contains
          if (nd.gt.0) call discre(itemp)
 
          !--check for special hydrogen and deuterium options
-          if (ncold.gt.0) call coldh(itemp,temp)
+         if (ncold.gt.0) call coldh(itemp,temp)
 
          !--check for skold option for correlations
-          if ((nsk.eq.2) .and. (ncold.eq.0))&
-             call skold(itemp,temp,ssm,nalpha,nbeta,ntempr)
+         if ((nsk.eq.2) .and. (ncold.eq.0))&
+            call skold(itemp,temp,ssm,nalpha,nbeta,ntempr)
 
       !--continue temperature loop
       enddo
@@ -413,7 +423,13 @@ contains
    isym=0
    if (ncold.ne.0) isym=1
    if (isabt.eq.1) isym=isym+2
-   mscr=4000
+
+   ! Based on endout, to write the actual TSL data, the max number of entries
+   ! needed in scr is either 8+2*nalpha, or 8+2*nedge. However, we have no way
+   ! of knowing how many comment lines were added to the leaper input. The
+   ! previous hard coded limit of 4000 is also used as a possible max as this
+   ! has apparently been sufficient to hold all comments in the past.
+   mscr = max(8 + 2*nalpha, 8 + 2*nedge, 4000)
    allocate(scr(mscr))
    call endout(ntempr,bragg,nedge,maxb,scr,mscr,isym,ilog)
 
@@ -445,14 +461,15 @@ contains
    !--------------------------------------------------------------------
    use physics ! provides pi
    use mainio  ! provides nsyso
+   use util    ! provides timer
    ! externals
    real(kr)::temp
    integer::itemp,np,maxn
    ! internals
    integer::i,j,k,n,npn,npl,iprt,jprt
-   integer,dimension(1000)::maxt
+   integer,allocatable,dimension(:)::maxt
    character(3)::tag
-   real(kr)::al,be,bel,ex,exx,st,add,sc,alp,alw,ssct,ckk
+   real(kr)::al,be,bel,ex,exx,st,add,sc,alp,alw,ssct,ckk,time
    real(kr)::ff0,ff1,ff2,ff1l,ff2l,sum0,sum1
    real(kr),dimension(:),allocatable::p,tlast,tnow,xa
    real(kr),parameter::therm=0.0253e0_kr
@@ -468,6 +485,7 @@ contains
    allocate(tlast(nphon*np1))
    allocate(tnow(nphon*np1))
    allocate(xa(nalpha))
+   allocate(maxt(nbeta))
 
    !--calculate various parameters for this temperature
    call start(itemp,p,np,deltab,tev)
@@ -498,8 +516,14 @@ contains
    do j=1,nbeta
       maxt(j)=nalpha+1
    enddo
-   if (iprint.eq.2)&
-     write(nsyso,'(/'' normalization check for phonon expansion'')')
+   if (iprint.eq.2) then
+      write(nsyso,'(/'' normalization check for phonon expansion'')')
+   endif
+   if (maxn.gt.maxnphon) then
+      call timer(time)
+      write(nsyse,'(/'' performing phonon expansion sum'',&
+            &37x,f8.1,''s'')')time
+   endif
    do n=2,maxn
       npn=np+npl-1
       call convol(p,tlast,tnow,np,npl,npn,deltab,ckk)
@@ -525,7 +549,18 @@ contains
          tlast(i)=tnow(i)
       enddo
       npl=npn
+      if (mod(n,maxnphon).eq.0) then
+         call timer(time)
+         write(nsyse,'(2x,i5,'' of '',i5,&
+               &'' loops done for phonon expansion sum'',17x,f8.1,''s'')')&
+               &n,maxn,time
+      endif
    enddo
+   if (maxn.gt.maxnphon) then
+      call timer(time)
+      write(nsyse,'(/'' done with phonon expansion sum'',&
+            &38x,f8.1,''s'')')time
+   endif
 
    !--print out start of sct range for each beta
    if (iprint.ne.0) then
@@ -865,8 +900,8 @@ contains
       if (ded.lt.delta) delta=ded
       nu=1
       if (iprt.eq.1.and.iprint.eq.2) write(nsyso,&
-        '(/'' delta d='',f12.6,5x,''delta b='',f12.6,&
-        &10x,''delta='',f12.6)') ded,deb,delta
+        '(/'' delta d='',e18.5,5x,''delta b='',e18.5,&
+        &10x,''delta='',e18.5)') ded,deb,delta
 
       !--make table of s-diffusion or s-free on this interval
       call stable(ap,sd,nsd,al,delta,iprt,nu,ndmax)
@@ -1207,6 +1242,10 @@ contains
       else
          sb(i)=0
       endif
+      ! if delta is to small for the current value of beta, increase it
+      do while (bet.eq.(bet+delta))
+         delta=delta*10
+      end do
       bet=bet+delta
    enddo
    return
@@ -2796,7 +2835,7 @@ contains
    real(kr)::scoh(1000)
    real(kr),parameter::angst=1.e-8_kr
    real(kr),parameter::therm=.0253e0_kr
-   real(kr),parameter::zero=0.0e0_kr
+   real(kr),parameter::zero=0.0
 
    !--apply the skold approximation
    tev=bk*abs(temp)

--- a/src/main.f90
+++ b/src/main.f90
@@ -2,7 +2,7 @@ program njoy
 !-----------------------------------------------------------------------
 !
 !    NJOY Nuclear Data Processing System
-!    Version 2016.72+IAEA/NDS updates
+!    Version 2016.73+IAEA/NDS updates
 !
 !-----------------------------------------------------------------------
 !

--- a/src/moder.f90
+++ b/src/moder.f90
@@ -693,18 +693,25 @@ contains
                      call moreio(nin,nout,nscr,a,nb,nw)
                   enddo
                   if (kbk.gt.0) then
-                     call listio(nin,nout,nscr,a,nb,nw)
-                     lbk=n1h
-                     if (lbk.eq.1) then
-                        call tab1io(nin,nout,nscr,a,nb,nw)
-                        do while (nb.ne.0)
-                           call moreio(nin,nout,nscr,a,nb,nw)
-                        enddo
-                        call tab1io(nin,nout,nscr,a,nb,nw)
-                        do while (nb.ne.0)
-                           call moreio(nin,nout,nscr,a,nb,nw)
-                        enddo
-                     endif
+                     do l=1,kbk
+                        call contio(nin,nout,nscr,a,nb,nw)
+                        lbk=l2h
+                        if (lbk.eq.1) then
+                           call tab1io(nin,nout,nscr,a,nb,nw)
+                           do while (nb.ne.0)
+                              call moreio(nin,nout,nscr,a,nb,nw)
+                           enddo
+                           call tab1io(nin,nout,nscr,a,nb,nw)
+                           do while (nb.ne.0)
+                              call moreio(nin,nout,nscr,a,nb,nw)
+                           enddo
+                        else if (lbk.eq.2.or.lbk.eq.3) then
+                           call listio(nin,nout,nscr,a,nb,nw)
+                           do while (nb.ne.0)
+                              call moreio(nin,nout,nscr,a,nb,nw)
+                           enddo
+                        endif
+                     enddo
                   endif
                   if (kps.eq.1)then
                      call listio(nin,nout,nscr,a,nb,nw)

--- a/src/samm.f90
+++ b/src/samm.f90
@@ -25,8 +25,8 @@ module samm
    logical::Want_Partial_U=.false.
 
    !--variables
-   integer::ngroup,mchan,nres,npp,ntriag,npar,lllmax,kkxlmn
-   integer::nrext,krext,nparr,nerm
+   integer::ngroup,mchan,nres,npp,ntriag,npar,lllmax,kkxlmn,nback
+   integer::nrext,nparr,nerm
    integer,dimension(12)::ngroupm,nppm,nresm
    integer,parameter::lllmaxx=10
    real(kr)::awr,su
@@ -36,11 +36,11 @@ module samm
    integer,dimension(:,:),allocatable::kza,kzb,ishift,lpent,mt
    real(kr),dimension(:,:),allocatable::pa,pb,sspin,parity
    integer,dimension(:,:),allocatable::nresg
-   integer,dimension(:,:,:),allocatable::ipp,lspin
+   integer,dimension(:,:,:),allocatable::ipp,lspin,backgr
+   real(kr),dimension(:,:,:,:),allocatable::backgrdata
    real(kr),dimension(:,:,:),allocatable::chspin,bound,rdeff,rdtru
    real(kr),dimension(:,:),allocatable::eres,gamgam
    real(kr),dimension(:,:,:),allocatable::gamma
-   real(kr),dimension(:,:,:,:),allocatable::parext
    integer,dimension(:,:),allocatable::nent,next
    real(kr),dimension(:,:),allocatable::goj
    real(kr),dimension(:,:,:),allocatable::zke,zkfe,zkte,zeta,echan
@@ -179,8 +179,9 @@ contains
    real(kr)::res(maxres)
    ! internals
    integer::jnow,nb,nw,lfw,nis,i,lru,lrf,nro,naps,mode,lrx,kf,ki
-   integer::nls,ner,j,ng,is,ll,iis,kchan,kpp,kres,kpar,jj,nrs,igroup
+   integer::nls,ner,j,ng,is,ll,iis,kchan,kpp,kres,kpar,jj,nrs,igroup,kback
    integer::nch,ich,iso,ier,ipp,kk,kki,kkf
+   integer::kbk,lbk
    real(kr)::spin,parity,parl,capj,capjmx,gamf,gamf2,el,e1,e2,gamx
    real(kr),dimension(2)::s
    real(kr),parameter::zero=0
@@ -205,9 +206,11 @@ contains
    npp=0
    mchan=0
    npar=0
+   nback=0
    kres=0
    kpp=0
    kchan=0
+   kback=0
 
    !--check for multiple isotopes
    if (nis.gt.1) then
@@ -511,15 +514,27 @@ contains
 
             !--loop over the spin groups
             kchan=0
+            kback=0
             kres=0
             kpar=0
             do igroup=1,ngroup
+
+               !--read particle pair information
                call listio(nin,0,0,res(jnow),nb,nw)
                jnow=jnow+nw
+               do while (nb.ne.0)
+                  call moreio(nin,0,0,res(jj),nb,nw)
+                  jj=jj+nw
+                  if (jj.gt.maxres) call error('s2sammy',&
+                    'res storage exceeded',' ')
+               enddo
+               kbk=l1h
                nch=n2h
                ich=nch-1
                nchan(igroup,ier)=ich
                if (ich.gt.kchan) kchan=ich
+
+               !--read resonance parameters
                call listio(nin,0,0,res(jnow),nb,nw)
                jj=jnow+nw
                do while (nb.ne.0)
@@ -531,9 +546,51 @@ contains
                nrs=nint(res(jnow+3))
                kpar=kpar+nrs*(ich+2)
                kres=kres+nrs
+
+               !--read background rmatrix elements
+               if (kbk.gt.0) then
+                  do i=1,kbk
+                     call contio(nin,0,0,res(jnow),nb,nw)
+                     lbk=l2h
+                     if (lbk.eq.1) then
+                        call tab1io(nin,0,0,res(jj),nb,nw)
+                        jj=jnow+nw
+                        do while (nb.ne.0)
+                           call moreio(nin,0,0,res(jj),nb,nw)
+                           jj=jj+nw
+                           if (jj.gt.maxres) call error('s2sammy',&
+                             'res storage exceeded',' ')
+                        enddo
+                        call tab1io(nin,0,0,res(jj),nb,nw)
+                        jj=jnow+nw
+                        do while (nb.ne.0)
+                           call moreio(nin,0,0,res(jj),nb,nw)
+                           jj=jj+nw
+                           if (jj.gt.maxres) call error('s2sammy',&
+                             'res storage exceeded',' ')
+                        enddo
+                        if ((jj-jnow+1).gt.kback) kback=jj-jnow+1
+                     else if (lbk.eq.2.or.lbk.eq.3) then
+                        call listio(nin,0,0,res(jj),nb,nw)
+                        jj=jnow+nw
+                        do while (nb.ne.0)
+                           call moreio(nin,0,0,res(jj),nb,nw)
+                           jj=jj+nw
+                           if (jj.gt.maxres) call error('s2sammy',&
+                             'res storage exceeded',' ')
+                        enddo
+                        if (lbk.eq.2) then
+                           if (7.gt.kback) kback=7
+                        else
+                           if (5.gt.kback) kback=5
+                        endif
+                     endif
+                  enddo
+               endif
             enddo
             if (kpar.gt.npar) npar=kpar
             if (kchan.gt.mchan) mchan=kchan
+            if (kback.gt.nback) nback=kback
             nresm(ier)=kres
             if (kres.gt.nres) nres=kres
          endif
@@ -571,8 +628,10 @@ contains
    real(kr)::el,eh,spin,ascat
    real(kr)::enode(nodmax),res(maxres)
    ! internals
+   character(80)::strng
    integer::nb,nw,nls,is,ng,ll,iis,i,ires,jj,nrs,llll,ig,igxm,lrx
    integer::j,ndig,kres,igroup,ichp1,ichan,ix,ich,ippx,igamma,l,nx,ires1
+   integer::kbk,lbk,lch,krm,ifg
    real(kr)::pari,parl,capj,capjmx,c,awri,apl,aptru,apeff,spinjj
    real(kr)::gamf,gamf2,s1,s2,hw,ehalf,ell,x,gamx,qx
    real(kr),dimension(:),allocatable::a
@@ -634,6 +693,8 @@ contains
          do j=1,ngroupm(ier)
             lspin(i,j,ier)=0
             chspin(i,j,ier)=0
+            backgr(i,j,ier)=0
+            backgrdata(i,igroup,ier,:)=0
          enddo
       enddo
       pari=1
@@ -761,7 +822,7 @@ contains
             gamma(1,ires,ier)=res(jj+3)
             gamgam(ires,ier)=res(jj+4)
             gamf=res(jj+5)
-         gamf=gamf*(-1)**ires
+            gamf=gamf*(-1)**ires
             gamx=0
             if (lrx.gt.0) gamx=res(jj+2)-res(jj+3)-res(jj+4)-res(jj+5)
             if (gamx.lt.1.e-7_kr) gamx=0
@@ -824,6 +885,8 @@ contains
          do j=1,ngroupm(ier)
             lspin(i,j,ier)=0
             chspin(i,j,ier)=0
+            backgr(i,j,ier)=0
+            backgrdata(i,igroup,ier,:)=0
          enddo
       enddo
       pari=1
@@ -985,6 +1048,16 @@ contains
       !--nls is really the number of spin groups for mode=7
       ngroup=nls
 
+      !--check krm and ifg
+      ifg=l1h
+      krm=l2h
+      if (ifg.ne.0) then
+        call error('rdsammy','reduced resonance widths are not supported (IFG=1)',' ')
+      endif
+      if (krm.ne.3) then
+        call error('rdsammy','LRF=7 currently only supports Reich-Moore (KRM=3)',' ')
+      endif
+
       !--read the list of particle-pair descriptions
       !--and store the values in the proper allocated arrays
       call listio(nin,0,0,res(jnow),nb,nw)
@@ -1023,8 +1096,16 @@ contains
 
          !--read the spin group information
          call listio(nin,0,0,res(jnow),nb,nw)
+         jj=jnow+nw
+         do while (nb.ne.0)
+            call moreio(nin,0,0,res(jj),nb,nw)
+            jj=jj+nw
+            if (jj.gt.maxres) call error('rdsammy',&
+              'res storage exceeded',' ')
+         enddo
          sspin(igroup,ier)=c1h
          parity(igroup,ier)=c2h
+         kbk=l1h
          ichp1=n2h
          ichan=ichp1-1
          ix=0
@@ -1044,6 +1125,8 @@ contains
                rdeff(i,igroup,ier)=res(jj+4)
                if (mt(ipp(i,igroup,ier),ier).eq.2) ascat=res(jj+4)
                rdtru(i,igroup,ier)=res(jj+5)
+               backgr(i,igroup,ier)=0
+               backgrdata(i,igroup,ier,:)=0
             endif
             jj=jj+6
          enddo
@@ -1057,7 +1140,7 @@ contains
             if (jj.gt.maxres) call error('rdsammy',&
               'res storage exceeded',' ')
          enddo
-         nresg(igroup,ier)=nint(res(jnow+3))
+         nresg(igroup,ier)=l2h
          if (nresg(igroup,ier).gt.0) then
             jj=jnow+6
             nx=6
@@ -1110,6 +1193,65 @@ contains
                   gamgam(kres,ier)=x
                endif
                jj=jj+nx
+            enddo
+         endif
+
+         !--read background rmatrix elements
+         if (kbk.gt.0) then
+            nrext=1
+            if (krm.ne.3) then
+               call error('rdsammy',&
+               'Background rmatrix elements in LRF=7 are only allowed for Reich-Moore (KRM=3)',' ')
+            endif
+            do l=1,kbk
+               call contio(nin,0,0,res(jnow),nb,nw)
+               lch=l1h
+               lbk=l2h
+               if (lbk.ne.0.and.lch.eq.1) then
+                  write(strng,'(''channel '',i3,'' in spin group '',i3,&
+                               &'' is the eliminated capture channel'')') lch,igroup
+                  call error('rdsammy',strng,&
+                             'Background rmatrix data is not allowed for this channel')
+               endif
+               if (lbk.ne.0.and.lch.ne.1) then
+                  backgr(lch-1,igroup,ier)=lbk
+               endif
+               if (lbk.eq.1) then
+                  !--store the tables
+                  jj=3
+                  backgrdata(lch-1,igroup,ier,1)=jj
+                  call tab1io(nin,0,0,backgrdata(lch-1,igroup,ier,jj),nb,nw)
+                  jj=jj+nw
+                  do while (nb.ne.0)
+                     call moreio(nin,0,0,backgrdata(lch-1,igroup,ier,jj),nb,nw)
+                     jj=jj+nw
+                  enddo
+                  backgrdata(lch-1,igroup,ier,2)=jj
+                  call tab1io(nin,0,0,backgrdata(lch-1,igroup,ier,jj),nb,nw)
+                  jj=jnow+nw
+                  do while (nb.ne.0)
+                     call moreio(nin,0,0,backgrdata(lch-1,igroup,ier,jj),nb,nw)
+                     jj=jj+nw
+                  enddo
+               else if (lbk.eq.2.or.lbk.eq.3) then
+                  call listio(nin,0,0,res(jnow),nb,nw)
+                  jj=jnow+nw
+                  do while (nb.ne.0)
+                     call moreio(nin,0,0,res(jj),nb,nw)
+                     jj=jj+nw
+                     if (jj.gt.maxres) call error('rdsammy',&
+                       'res storage exceeded',' ')
+                  enddo
+                  backgrdata(lch-1,igroup,ier,1)=c1h
+                  backgrdata(lch-1,igroup,ier,2)=c2h
+                  backgrdata(lch-1,igroup,ier,3)=res(jnow+6)
+                  backgrdata(lch-1,igroup,ier,4)=res(jnow+7)
+                  backgrdata(lch-1,igroup,ier,5)=res(jnow+8)
+                  if (lbk.eq.2) then
+                     backgrdata(lch-1,igroup,ier,6)=res(jnow+9)
+                     backgrdata(lch-1,igroup,ier,7)=res(jnow+10)
+                  endif
+               endif
             enddo
          endif
       enddo
@@ -1444,6 +1586,8 @@ contains
    allocate(nresg(ngroup,nerm))
    allocate(ipp(mchan,ngroup,nerm))
    allocate(lspin(mchan,ngroup,nerm))
+   allocate(backgr(mchan,ngroup,nerm))
+   allocate(backgrdata(mchan,ngroup,nerm,nback))
    allocate(chspin(mchan,ngroup,nerm))
    allocate(bound(mchan,ngroup,nerm))
    allocate(rdeff(mchan,ngroup,nerm))
@@ -1451,7 +1595,6 @@ contains
    allocate(eres(nres,nerm))
    allocate(gamgam(nres,nerm))
    allocate(gamma(mchan,nres,nerm))
-   allocate(parext(7,mchan,ngroup,nerm))
    allocate(nent(nres,nerm))
    allocate(next(nres,nerm))
    allocate(goj(nres,nerm))
@@ -1911,11 +2054,15 @@ contains
                iduu(knpar,ier)=0
                if (Want_Partial_U) then
                   uuuu(knpar,ier)=1
-               else
-                  if (kqq.ne.5) uuuu(knpar,ier)=parext(kqq,j,kgroup,ier)
-                  if (kqq.eq.5) uuuu(knpar,ier)=sqrt(parext(kqq,j,kgroup,ier))
                endif
             enddo
+            uuuu(1,ier)=backgrdata(j,kgroup,ier,1)
+            uuuu(2,ier)=backgrdata(j,kgroup,ier,2)
+            uuuu(3,ier)=backgrdata(j,kgroup,ier,3)
+            uuuu(4,ier)=backgrdata(j,kgroup,ier,4)
+            uuuu(5,ier)=sqrt(backgrdata(j,kgroup,ier,6))
+            uuuu(6,ier)=backgrdata(j,kgroup,ier,7)
+            uuuu(7,ier)=backgrdata(j,kgroup,ier,5)
          enddo
       enddo
    endif
@@ -2928,9 +3075,6 @@ contains
       enddo
    endif
 
-   krext=nrext
-   if (krext.eq.0) krext=1
-
    !--do loop over spin-parity groups
 
    kstart=0
@@ -3088,12 +3232,13 @@ contains
    !-------------------------------------------------------------------
    ! Generate the R-matrix and other arrays.
    !-------------------------------------------------------------------
+   use endf    ! provides terpa
    ! externals
    integer::n,lrmat,min,max,nent,nchan,ier
    ! internals
-   integer::nnntot,i,kl,k,l,ires,ii,ipx,iffy,kk,kx,kkx,j,ji
+   integer::nnntot,i,kl,k,l,ires,ii,ipx,iffy,kk,kx,kkx,j,ji,ip,ir,idis
    integer::lsp,jdopha
-   real(kr)::aloge,ex,rho,rhof,eta,hr,hi,p,dp,ds
+   real(kr)::aloge,ex,rho,rhof,eta,hr,hi,p,dp,ds,esum,ediff,temp,enext
    real(kr)::sinphx,cosphx,dphix
    real(kr)::hrx,hix,px,dpx,dsx
    real(kr),parameter::zero=0
@@ -3113,16 +3258,38 @@ contains
    !--initialize R-matrix
    kl=0
    do k=1,nchan
-      if (nrext.ne.0) aloge=log((parext(2,k,n,ier)-su)/(su-parext(1,k,n,ier)))
       do l=1,k
          kl=kl+1
          rmat(1,kl,ier)=0
          rmat(2,kl,ier)=0
-         if (l.eq.k.and.nrext.ne.0) then
-            rmat(1,kl,ier)=parext(3,k,n,ier)+parext(4,k,n,ier)*su&
-             -parext(5,k,n,ier)*aloge+parext(7,k,n,ier)*su**2&
-             -parext(6,k,n,ier)*(parext(2,k,n,ier)-parext(1,k,n,ier))&
-             -parext(6,k,n,ier)*aloge*su
+         if (l.eq.k) then
+            ! add background rmatrix elements if defined for the channel
+            if (backgr(k,n,ier).gt.0) then
+               if (backgr(k,n,ier).eq.1) then      ! arbitrary tabulated complex function
+                  ip=2
+                  ir=1
+                  call terpa(rmat(1,kl,ier),su,enext,idis,&
+                             backgrdata(k,n,ier,3),ip,ir)
+                  ip=2
+                  ir=1
+                  call terpa(rmat(2,kl,ier),su,enext,idis,&
+                             backgrdata(k,n,ier,int(backgrdata(k,n,ier,2))),ip,ir)
+               else if (backgr(k,n,ier).eq.2) then ! Sammy parametrisation
+                  rmat(1,kl,ier)=backgrdata(k,n,ier,3)&
+                                -backgrdata(k,n,ier,7)*(backgrdata(k,n,ier,2)-backgrdata(k,n,ier,1))&
+                                +(backgrdata(k,n,ier,4)+backgrdata(k,n,ier,5)*su)*su&
+                                -(backgrdata(k,n,ier,6)+backgrdata(k,n,ier,7)*su)&
+                                *log((backgrdata(k,n,ier,2)-su)/(su-backgrdata(k,n,ier,1)))
+               else if (backgr(k,n,ier).eq.3) then ! Frohner parametrisation
+                   esum=backgrdata(k,n,ier,1)+backgrdata(k,n,ier,2)
+                   ediff=backgrdata(k,n,ier,2)-backgrdata(k,n,ier,1)
+                   rmat(1,kl,ier)=backgrdata(k,n,ier,3)&
+                                 +2.*backgrdata(k,n,ier,4)&
+                                 *atanh((2.*su-esum)/ediff)
+                   rmat(2,kl,ier)=backgrdata(k,n,ier,5)/ediff&
+                                 /(1.-((2.*su-esum)/ediff)**2)
+               endif
+            endif
          endif
       enddo
    enddo
@@ -3189,7 +3356,7 @@ contains
 
          else
 
-            !)--and here it is
+            !--and here it is
             lsp=lspin(i,n,ier)
             ex=sqrt(su-echan(i,n,ier))
             rho=zkte(i,n,ier)*ex
@@ -6684,6 +6851,7 @@ contains
 
    subroutine derext(n,nchan,jstart,nnnn,ier)
    !-------------------------------------------------------------------
+   use util ! provides error
    ! externals
    integer::n,nchan,jstart,nnnn,ier
    ! internals
@@ -6693,6 +6861,12 @@ contains
    !--angle-integrated
    ij=0
    do i=1,nchan
+
+      !--only for the Sammy background option
+      if (backgr(i,nnnn,ier).ne.2) then
+         call error('derext','Partial derivatives are only coded for the Sammy formalism','')
+      endif
+
       ij=ij+I
       !  note that tr = 1/2 times partial (sigma) wrt (re R),
       !  ergo need to multiply by 2 here
@@ -6700,17 +6874,17 @@ contains
       jstart=jstart+1
       do m=1,npp
          if (m.le.2) then
-            deriv(m,jstart,ier)=-tr(m,ij,ier)*a*(parext(5,i,nnnn,ier)+&
-              parext(6,i,nnnn,ier)*parext(1,i,nnnn,ier))/&
-              (su-parext(1,i,nnnn,ier))
+            deriv(m,jstart,ier)=-tr(m,ij,ier)*a*(backgrdata(i,nnnn,ier,6)+&
+              backgrdata(i,nnnn,ier,7)*backgrdata(i,nnnn,ier,1))/&
+              (su-backgrdata(i,nnnn,ier,1))
          endif
       enddo
       jstart=jstart+1
       do m=1,npp
          if (m.le.2) then
-            deriv(m,jstart,ier)=-tr(m,ij,ier)*a*(parext(5,i,nnnn,ier)+&
-              parext(6,I,nnnn,ier)*parext(2,i,nnnn,ier))/&
-             (parext(2,i,nnnn,ier)-su)
+            deriv(m,jstart,ier)=-tr(m,ij,ier)*a*(backgrdata(i,nnnn,ier,6)+&
+              backgrdata(I,nnnn,ier,7)*backgrdata(i,nnnn,ier,2))/&
+             (backgrdata(i,nnnn,ier,2)-su)
          endif
       enddo
       jstart=jstart+1
@@ -6728,18 +6902,18 @@ contains
       jstart=jstart+1
       do m=1,npp
          if (m.le.2) then
-            deriv(m,jstart,ier)=-2*tr(m,ij,ier)*a*sqrt(parext(5,i,nnnn,ier))*&
-              log((parext(2,i,nnnn,ier)-su)/(su-parext(1,i,nnnn,ier)))
+            deriv(m,jstart,ier)=-2*tr(m,ij,ier)*a*sqrt(backgrdata(i,nnnn,ier,6))*&
+              log((backgrdata(i,nnnn,ier,2)-su)/(su-backgrdata(i,nnnn,ier,1)))
               !   Remember that the u-parameter is the
-              !   square root of parext(5)
+              !   square root of backgrdata(6)
          endif
       enddo
       jstart=jstart+1
       do m=1,npp
          if (m.le.2) then
             deriv(m,jstart,ier)=-tr(m,ij,ier)*a*&
-              ((parext(2,i,nnnn,ier)-parext(1,i,nnnn,ier))+&
-              su*log((parext(2,i,nnnn,ier)-su)/(su-parext(1,i,nnnn,ier))))
+              ((backgrdata(i,nnnn,ier,2)-backgrdata(i,nnnn,ier,1))+&
+              su*log((backgrdata(i,nnnn,ier,2)-su)/(su-backgrdata(i,nnnn,ier,1))))
          endif
       enddo
       jstart=jstart+1
@@ -6965,6 +7139,8 @@ contains
    if (allocated(nresg)) deallocate(nresg)
    if (allocated(ipp)) deallocate(ipp)
    if (allocated(lspin)) deallocate(lspin)
+   if (allocated(backgr)) deallocate(backgr)
+   if (allocated(backgrdata)) deallocate(backgrdata)
    if (allocated(chspin)) deallocate(chspin)
    if (allocated(bound)) deallocate(bound)
    if (allocated(rdeff)) deallocate(rdeff)
@@ -6972,7 +7148,6 @@ contains
    if (allocated(eres)) deallocate(eres)
    if (allocated(gamgam)) deallocate(gamgam)
    if (allocated(gamma)) deallocate(gamma)
-   if (allocated(parext)) deallocate(parext)
    if (allocated(nent)) deallocate(nent)
    if (allocated(next)) deallocate(next)
    if (allocated(goj)) deallocate(goj)

--- a/src/thermr.f90
+++ b/src/thermr.f90
@@ -2494,7 +2494,7 @@ contains
    ! internals
    integer::nb1,na1,i,ib,ia
    real(kr)::rtev,bb,a,sigc,b,c,bbb,s,s1,s2,s3,arg
-   real(kr)::tfff,tfff2,rat
+   real(kr)::tfff,tfff2
    real(kr),parameter::sigmin=1.e-10_kr
    real(kr),parameter::sabflg=-225.e0_kr
    real(kr),parameter::amin=1.e-6_kr

--- a/src/vers.f90
+++ b/src/vers.f90
@@ -3,6 +3,6 @@ module version
    ! These values are updated during the NJOY revision-control process.
    implicit none
    private
-   character(8),public::vers='2016.72+'
-   character(8),public::vday='21Oct23'
+   character(8),public::vers='2016.73+'
+   character(8),public::vday='10Nov23'
 end module version


### PR DESCRIPTION
The modules `aceth`, `groupr`,`leapr`,`moder`, `samm` and `thermr` were taken from NJOY2016.73 to include LANL updates.
The `group` and `leapr`  were also modified to consider minor local updates
The rest of the modules include updates to generate the FENDL, IRDFF-II,ADS-Lib and WIMSD libraries